### PR TITLE
Spawn off a terminal emulator to install packages if needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linked-hash-map"


### PR DESCRIPTION
If we're not already inside a terminal, we need to run the package installation _somewhere_, otherwise it'll be completely invisible to the user.