### PR TITLE
Show dialog boxes to guide the user when run outside of a terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "nix",
  "serde",
  "xdg",
+ "zenity-dialog",
 ]
 
 [[package]]
@@ -371,7 +372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 2.0.11",
  "ucd-trie",
 ]
 
@@ -539,11 +540,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.11",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -688,4 +709,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zenity-dialog"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58a030e8e052cb54f6793de1b5e1e1489825704c9ac41b6f06ab25d4bfee118"
+dependencies = [
+ "anyhow",
+ "thiserror 1.0.69",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ log = "0.4"
 nix = "0.29"
 serde = { version = "1.0", features = ["derive"] }
 xdg = "2.5"
+zenity-dialog = { version = "0.3.6", default-features = false, features = ["info", "error"] }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ binfmt-dispatcher parses configuration from several sources:
 Configs are parsed in order and later settings win. A fully commented config is [provided](docs/binfmt-dispatcher.toml.example) and should be fairly self-explanatory.
 
 ## Usage
-When run as an interpreter, binfmt-dispatcher will parse the configs, pick the best interpreter to use based on it and the binary being run, and then run it. If enabled (via the `use_muvm` config setting), binfmt-dispatcher will use [muvm](https://github.com/AsahiLinux/muvm) to execute the interpreter in a microVM if the system page-size is not 4k.
+When run as an interpreter, binfmt-dispatcher will parse the configs, pick the best interpreter to use based on it and the binary being run, and then run it. If enabled (via the `use_muvm` config setting), binfmt-dispatcher will use [muvm](https://github.com/AsahiLinux/muvm) to execute the interpreter in a microVM if the system page-size is not 4k. If the interpreter or any of its dependencies are missing, binfmt-dispatcher will attempt to install them by invoking the package manager.
+
+If run outside of a terminal session, binfmt-dispatcher will assume it's being run as part of a desktop environment (e.g. because a user double clicked on an x86-64 binary in a file manager). If [zenity](https://help.gnome.org/users/zenity/stable/) is installed, dialog boxes will be displayed to provide feedback to the user when necessary. If it's necessary to install any missing dependencies, the package manager will be run inside a terminal emulator via [xdg-terminal-exec](https://github.com/Vladimir-csp/xdg-terminal-exec).
 
 ## License
 This project is [MIT](https://spdx.org/licenses/MIT.html) licensed. See the [LICENSE](LICENSE) file for the full text of the license.

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,12 @@
 use libc::{sysconf, _SC_PAGESIZE};
 use std::os::raw::c_long;
 
+use zenity_dialog::dialog;
+use zenity_dialog::ZenityDialog;
+use zenity_dialog::ZenityOutput;
+
+use log::warn;
+
 pub fn get_page_size() -> Option<usize> {
     unsafe {
         let page_size: c_long = sysconf(_SC_PAGESIZE);
@@ -11,5 +17,37 @@ pub fn get_page_size() -> Option<usize> {
         } else {
             Some(page_size as usize)
         }
+    }
+}
+
+pub fn info_dialog(msg: &str) -> bool {
+    let result = ZenityDialog::new(dialog::Info::new().with_text(msg))
+        .with_title(env!("CARGO_PKG_NAME"))
+        .show();
+
+    if result.is_err() {
+        warn!("Failed to create dialog, is zenity installed?");
+        return false;
+    }
+
+    match result.unwrap() {
+        ZenityOutput::Affirmed { .. } => return true,
+        _ => return false,
+    }
+}
+
+pub fn error_dialog(msg: &str) -> bool {
+    let result = ZenityDialog::new(dialog::Error::new().with_text(msg))
+        .with_title(env!("CARGO_PKG_NAME"))
+        .show();
+
+    if result.is_err() {
+        warn!("Failed to create dialog, is zenity installed?");
+        return false;
+    }
+
+    match result.unwrap() {
+        ZenityOutput::Affirmed { .. } => return true,
+        _ => return false,
     }
 }


### PR DESCRIPTION
This provides some basic UI prompts to make things a bit more user friendly. We're using zenity instead of relying on an actual UI toolkit to keep dependencies to a minimum, as in the happy path these should only come in play on the first execution.